### PR TITLE
fix: add missing elliptic dependency in package.json

### DIFF
--- a/operations/transaction-service/package.json
+++ b/operations/transaction-service/package.json
@@ -31,6 +31,7 @@
     "@nestjs/swagger": "^7.1.12",
     "class-transformer": "^0.5.1",
     "dotenv": "^16.4.2",
+    "elliptic": "^6.6.1",
     "ethers": "5.7.0",
     "jsonwebtoken": "^9.0.2",
     "reflect-metadata": "^0.1.13",


### PR DESCRIPTION
Fix for the following critical error in Choreo build in Transaction Service:
<img width="763" height="179" alt="Choreo Build Error Logs" src="https://github.com/user-attachments/assets/4da1e937-4f14-4ac0-bf93-ffdc5b69a281" />
