### PR TITLE
[Transaction Service] Revert wallet config path and sync openapi.yaml with new endpoint

### DIFF
--- a/operations/transaction-service/openapi.yaml
+++ b/operations/transaction-service/openapi.yaml
@@ -95,6 +95,31 @@ paths:
         '500':
           description: Server Error.
 
+  /api/v1/blockchain/transactions/search:
+    post:
+      operationId: BlockchainController_browseTransactions
+      summary: Search Transfer events with optional filters and pagination
+      tags:
+        - Transactional
+      requestBody:
+        required: false
+        description: Optional filters and pagination parameters.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BrowseTransactionsDto'
+      responses:
+        '200':
+          description: Successfully retrieved transactions.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransactionListResponseDto'
+        '400':
+          description: Bad request.
+        '500':
+          description: Server Error.
+
   /api/v1/blockchain/get-transaction-details/{txHash}:
     get:
       operationId: BlockchainController_getTransactionDetailsByTxHash
@@ -297,6 +322,116 @@ components:
           description: HTTP status code of the response.
         payload:
           $ref: '#/components/schemas/TransactionDetailsDto'
+      required:
+        - message
+        - httpCode
+        - payload
+
+    BrowseTransactionsDto:
+      type: object
+      properties:
+        senderAddresses:
+          type: array
+          items:
+            type: string
+          description: Filter by sender (from) wallet address(es).
+        receiverAddresses:
+          type: array
+          items:
+            type: string
+          description: Filter by receiver (to) wallet address(es).
+        transactionHash:
+          type: string
+          description: Filter by exact transaction hash.
+        startTime:
+          type: string
+          format: date-time
+          description: Return only transactions after this time (ISO-8601, exclusive).
+        endTime:
+          type: string
+          format: date-time
+          description: Return only transactions before this time (ISO-8601, exclusive).
+        limit:
+          type: integer
+          minimum: 1
+          maximum: 100
+          default: 10
+          description: Maximum number of results to return (1-100). Defaults to 10.
+        offset:
+          type: integer
+          minimum: 0
+          default: 0
+          description: Number of results to skip for pagination. Defaults to 0.
+
+    TransactionItemDto:
+      type: object
+      properties:
+        txHash:
+          type: string
+          description: Transaction hash (0x-prefixed).
+        blockNumber:
+          type: integer
+          description: Block number in which the transaction was mined.
+        senderAddress:
+          type: string
+          description: Sender wallet address.
+        receiverAddress:
+          type: string
+          description: Receiver wallet address.
+        amount:
+          type: string
+          description: Transferred amount formatted using token decimals (human-readable).
+        amountRaw:
+          type: string
+          description: Raw transferred amount as an unformatted string.
+        timestamp:
+          type: string
+          format: date-time
+          nullable: true
+          description: ISO-8601 timestamp of the block, or null if unavailable.
+      required:
+        - txHash
+        - blockNumber
+        - senderAddress
+        - receiverAddress
+        - amount
+        - amountRaw
+        - timestamp
+
+    TransactionListDto:
+      type: object
+      properties:
+        hasMore:
+          type: boolean
+          description: Whether more results exist beyond the current page.
+        offset:
+          type: integer
+          description: Number of results skipped.
+        limit:
+          type: integer
+          description: Maximum number of results returned per page.
+        transactions:
+          type: array
+          items:
+            $ref: '#/components/schemas/TransactionItemDto'
+          description: List of matching transactions, ordered newest first.
+      required:
+        - hasMore
+        - offset
+        - limit
+        - transactions
+
+    TransactionListResponseDto:
+      type: object
+      properties:
+        message:
+          type: string
+          description: A message indicating the result of the API request.
+        httpCode:
+          type: number
+          description: HTTP status code of the response.
+        payload:
+          $ref: '#/components/schemas/TransactionListDto'
       required:
         - message
         - httpCode

--- a/operations/transaction-service/src/common/wallet-config.service.ts
+++ b/operations/transaction-service/src/common/wallet-config.service.ts
@@ -7,7 +7,6 @@
 
 import { Injectable, Logger } from '@nestjs/common';
 import { readFileSync, existsSync } from 'fs';
-import { join } from 'path';
 
 export interface WalletConfig {
   PUBLIC_WALLET_ADDRESS: string;
@@ -20,7 +19,7 @@ export class WalletConfigService {
   private readonly logger = new Logger(WalletConfigService.name);
   getWalletConfig(clientId: string): WalletConfig | undefined {
     try {
-      const configPath = join(process.cwd(), 'src/config/client-address-mapping.json');
+      const configPath = '/src/config/client-address-mapping.json';
       if (!existsSync(configPath)) {
         this.logger.warn(`Wallet config file not found at ${configPath}`);
         return undefined;


### PR DESCRIPTION
This pull request introduces a new API endpoint for searching blockchain transactions with flexible filtering and pagination, and adds the necessary data transfer object (DTO) schemas to support this functionality in the OpenAPI specification. Additionally, it makes a minor path update in the wallet config service.

**API Enhancements:**

* Added a new `POST /api/v1/blockchain/transactions/search` endpoint to allow searching for transfer events with optional filters (such as sender, receiver, transaction hash, time range) and pagination support.

* Defined new DTO schemas in the OpenAPI spec:
  - `BrowseTransactionsDto` for search filters and pagination.
  - `TransactionItemDto` for individual transaction details.
  - `TransactionListDto` for paginated results.
  - `TransactionListResponseDto` for the API response structure.

**Code Maintenance:**

* Removed unused import of `join` from `path` in `wallet-config.service.ts`.
* Updated the config file path in `WalletConfigService` from using `join(process.cwd(), ...)` to a hardcoded string `'/src/config/client-address-mapping.json'`.