### PR TITLE
[Wallet Service] Refactor JWT handling by removing UUID validation

### DIFF
--- a/operations/wallet-service/jwtInterceptor.bal
+++ b/operations/wallet-service/jwtInterceptor.bal
@@ -9,7 +9,6 @@ import ballerina/log;
 
 const X_JWT_ASSERTION = "x-jwt-assertion";
 const EMAIL = "email";
-const UUID = "uuid";
 
 # Request Interceptor used to decode the JWT.
 service class JwtInterceptor {
@@ -32,13 +31,12 @@ service class JwtInterceptor {
             log:printError("Error while decoding JWT", jwtInfo);
             return http:FORBIDDEN;
         }
-        JwtPayload {email, userid} = jwtInfo;
-        if isEmptyVal(email) || isEmptyVal(userid) {
-            log:printWarn("Email or userid is empty in the JWT");
+        JwtPayload {email, sub} = jwtInfo;
+        if isEmptyVal(email) && isEmptyVal(sub) {
+            log:printWarn("Email is empty in the JWT");
             return http:FORBIDDEN;
         }
-        ctx.set(EMAIL, email);
-        ctx.set(UUID, userid);
+        ctx.set(EMAIL, sub is string ? sub : email);
         return ctx.next();
     }
 }

--- a/operations/wallet-service/jwtInterceptor.bal
+++ b/operations/wallet-service/jwtInterceptor.bal
@@ -33,7 +33,7 @@ service class JwtInterceptor {
         }
         JwtPayload {email, sub} = jwtInfo;
         if isEmptyVal(email) && isEmptyVal(sub) {
-            log:printWarn("Email is empty in the JWT");
+            log:printWarn("Both email and sub are empty in the JWT");
             return http:FORBIDDEN;
         }
         ctx.set(EMAIL, sub is string ? sub : email);

--- a/operations/wallet-service/service.bal
+++ b/operations/wallet-service/service.bal
@@ -29,19 +29,9 @@ service http:InterceptableService / on new http:Listener(9091) {
 
         string walletAddress = payload.walletAddress;
 
-        string|error email = ctx.getWithType(EMAIL);
-        if email is error {
-            log:printError("Failed to get user email from context", email);
-            return <http:InternalServerError>{body: {"message": ERR_MSG_CREATE_WALLET}};
-        }
-        string? uuid = ();
-        string|error uuidResult = ctx.getWithType(UUID);
-        if uuidResult is string {
-            uuid = uuidResult;
-        }
-        string|error userIdentifier = getUserIdentifier(email, uuid);
-        if userIdentifier is error {
-            log:printError("Failed to resolve user identifier", userIdentifier);
+        string|error userEmail = ctx.getWithType(EMAIL);
+        if userEmail is error {
+            log:printError("Failed to get user email from context", userEmail);
             return <http:InternalServerError>{body: {"message": ERR_MSG_CREATE_WALLET}};
         }
 
@@ -58,11 +48,11 @@ service http:InterceptableService / on new http:Listener(9091) {
 
         transaction {
             types:UserWallet userWallet = {
-                userEmail: userIdentifier,
+                userEmail,
                 walletAddress
             };
             boolean isFirstWallet = check database:isUserFirstWallet(userWallet.userEmail);
-            if isFirstWallet && email.endsWith(WSO2_EMAIL_SUFFIX) {
+            if isFirstWallet && userEmail.endsWith(WSO2_EMAIL_SUFFIX) {
                 userWallet.initialCoinsAllocated = transactions:initialCoins;
                 check database:insertUserWallet(userWallet);
                 boolean coinsAllocated = check transactions:allocateInitialCoins(walletAddress);
@@ -95,21 +85,11 @@ service http:InterceptableService / on new http:Listener(9091) {
             log:printError("Failed to get user email from context", email);
             return <http:InternalServerError>{body: {"message": ERR_MSG_FETCH_WALLETS}};
         }
-        string? uuid = ();
-        string|error uuidResult = ctx.getWithType(UUID);
-        if uuidResult is string {
-            uuid = uuidResult;
-        }
-        string|error identifier = getUserIdentifier(email, uuid);
-        if identifier is error {
-            log:printError("Failed to resolve user identifier", identifier);
-            return <http:InternalServerError>{body: {"message": ERR_MSG_FETCH_WALLETS}};
-        }
 
-        types:WalletAddressInfo[]|error walletList = database:getWalletAddressesByEmail(identifier);
-
+        types:WalletAddressInfo[]|error walletList = database:getWalletAddressesByEmail(email);
+        
         if walletList is error {
-            log:printError(string `Failed to fetch wallet addresses for user ${identifier}`, walletList);
+            log:printError(string `Failed to fetch wallet addresses for user ${email}`, walletList);
             return <http:InternalServerError>{body: {"message": ERR_MSG_FETCH_WALLETS}};
         }
 
@@ -151,17 +131,7 @@ service http:InterceptableService / on new http:Listener(9091) {
             log:printError("Failed to get user email from context", email);
             return <http:InternalServerError>{body: {"message": ERR_MSG_SET_PRIMARY}};
         }
-        string? uuid = ();
-        string|error uuidResult = ctx.getWithType(UUID);
-        if uuidResult is string {
-            uuid = uuidResult;
-        }
-        string|error identifier = getUserIdentifier(email, uuid);
-        if identifier is error {
-            log:printError("Failed to resolve user identifier", identifier);
-            return <http:InternalServerError>{body: {"message": ERR_MSG_SET_PRIMARY}};
-        }
-
+        
         types:UserWallet|error? walletDetails = database:getUserWallet(address);
         if walletDetails is error {
             log:printError(string `Error getting wallet details for ${address}`, walletDetails);
@@ -169,14 +139,14 @@ service http:InterceptableService / on new http:Listener(9091) {
         } else if walletDetails is () {
             log:printWarn(string `Wallet ${address} not found`);
             return http:NOT_FOUND;
-        } else if walletDetails.userEmail != identifier {
-            log:printWarn(string `Wallet ${address} does not belong to user ${identifier}.`);
+        } else if walletDetails.userEmail != email {
+            log:printWarn(string `Wallet ${address} does not belong to user ${email}.`);
             return http:FORBIDDEN;
         }
 
-        error? result = database:setWalletAsPrimary(identifier, address);
+        error? result = database:setWalletAsPrimary(email, address);
         if result is error {
-            log:printError(string `Failed to set wallet ${address} as primary for user ${identifier}`, result);
+            log:printError(string `Failed to set wallet ${address} as primary for user ${email}`, result);
             return <http:InternalServerError>{body: {"message": ERR_MSG_SET_PRIMARY}};
         }
         return http:OK;

--- a/operations/wallet-service/types.bal
+++ b/operations/wallet-service/types.bal
@@ -11,6 +11,4 @@ public type JwtPayload record {
     string? email = ();
     # Subject
     string? sub = ();
-    # Asgardeo user ID
-    string? userid = ();
 };

--- a/operations/wallet-service/utils.bal
+++ b/operations/wallet-service/utils.bal
@@ -21,19 +21,3 @@ public isolated function jwtDecoder(string jwt) returns JwtPayload|error {
 # + return - If empty return TRUE, else return FALSE
 public isolated function isEmptyVal(string? val) returns boolean =>
     val is () || val.trim().length() == 0;
-
-# Returns the identifier used to store/query a user's wallet.
-# WSO2 users are identified by their email; all others by their UUID to avoid storing PII.
-#
-# + email - User email from JWT
-# + uuid - User UUID (sub claim) from JWT
-# + return - Identifier string or error if UUID is missing for a non-WSO2 user
-public isolated function getUserIdentifier(string email, string? uuid) returns string|error {
-    if email.endsWith(WSO2_EMAIL_SUFFIX) {
-        return email;
-    }
-    if isEmptyVal(uuid) || uuid is () {
-        return error("UUID not available for non-WSO2 user");
-    }
-    return uuid;
-}


### PR DESCRIPTION
Reverts #134 

This pull request simplifies user identification in the wallet service by consistently using the `email` or `sub` (subject) claim from the JWT, and removes the previous logic that distinguished between WSO2 and non-WSO2 users using a UUID. The changes eliminate the `UUID` constant, the `userid` field in JWT payloads, and the `getUserIdentifier` utility function, streamlining how user information is extracted and used throughout the codebase.

**JWT and User Identification Simplification:**

* The `JwtPayload` type no longer includes the `userid` field; now only `email` and `sub` are used for user identification.
* The `JwtInterceptor` service now sets the `EMAIL` context value to either the `sub` claim (if it's a string) or the `email` claim, and no longer uses or sets a UUID.
* The logic for extracting user identifiers in the service endpoints has been simplified: all references to UUIDs and the `getUserIdentifier` function have been removed, and only the `EMAIL` context value is used. [[1]](diffhunk://#diff-bad6933235982475d8007b70b327bd3bdf095666884ca0cab69e2d8d21f79333L32-R34) [[2]](diffhunk://#diff-bad6933235982475d8007b70b327bd3bdf095666884ca0cab69e2d8d21f79333L61-R55) [[3]](diffhunk://#diff-bad6933235982475d8007b70b327bd3bdf095666884ca0cab69e2d8d21f79333L98-R92) [[4]](diffhunk://#diff-bad6933235982475d8007b70b327bd3bdf095666884ca0cab69e2d8d21f79333L154-L163) [[5]](diffhunk://#diff-bad6933235982475d8007b70b327bd3bdf095666884ca0cab69e2d8d21f79333L172-R149)
* The `getUserIdentifier` utility function has been removed from `utils.bal`, as it is no longer needed.

**Constants cleanup:**

* The `UUID` constant has been removed, as UUIDs are no longer used for user identification.