### PR TITLE
[Wallet App] Remove iOS gate for safe-bottom-insets

### DIFF
--- a/apps/wso2-digital-wallet/src/LayoutView.js
+++ b/apps/wso2-digital-wallet/src/LayoutView.js
@@ -22,17 +22,6 @@ import { requestDeviceSafeAreaInsets } from "./microapp-bridge";
 
 const MIN_BOTTOM_PADDING_PX = 8;
 
-const isIOSDevice = () => {
-  if (typeof navigator === "undefined") return false;
-  const ua = navigator.userAgent || "";
-  if (/iPad|iPhone|iPod/.test(ua)) return true;
-  return (
-    navigator.platform === "MacIntel" &&
-    typeof navigator.maxTouchPoints === "number" &&
-    navigator.maxTouchPoints > 1
-  );
-};
-
 function LayoutView() {
   const { Content } = Layout;
   const location = useLocation();
@@ -90,9 +79,7 @@ function LayoutView() {
           );
         }
         if (typeof bottom === "number") {
-          const value = isIOSDevice()
-            ? Math.max(MIN_BOTTOM_PADDING_PX, bottom)
-            : MIN_BOTTOM_PADDING_PX;
+          const value = Math.max(MIN_BOTTOM_PADDING_PX, bottom);
           document.documentElement.style.setProperty(
             "--safe-area-bottom",
             `${value}px`,


### PR DESCRIPTION
This pull request simplifies the logic for setting the bottom safe area padding in the `LayoutView` component by removing device-specific checks for iOS. Now, the padding always uses the maximum of the minimum padding or the reported bottom value, regardless of device type.

Layout padding simplification:

* Removed the `isIOSDevice` function from `LayoutView.js`, eliminating device-specific detection logic.
* Updated the calculation for bottom padding to always use `Math.max(MIN_BOTTOM_PADDING_PX, bottom)`, removing the conditional logic that previously applied only for iOS devices.